### PR TITLE
Several improvement on binary parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.olean
 result*
+/build
+/lean_packages/*
+!/lean_packages/manifest.json

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,0 +1,9 @@
+import Lake
+open Lake DSL
+
+package parsec {
+  srcDir := "src"
+}
+
+@[defaultTarget]
+lean_lib Parsec

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,5 +6,5 @@ package parsec {
   precompileModules := true
 }
 
-@[defaultTarget]
+@[default_target]
 lean_lib Parsec

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -3,6 +3,7 @@ open Lake DSL
 
 package parsec {
   srcDir := "src"
+  precompileModules := true
 }
 
 @[defaultTarget]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:nightly-2022-06-16

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-06-16
+leanprover/lean4:nightly-2022-06-30

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-06-30
+leanprover/lean4:nightly-2022-07-06

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-07-06
+leanprover/lean4:nightly-2022-11-04

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -86,6 +86,12 @@ def read64LE : Parser UInt64 := do
 def read64BE : Parser UInt64 := do
   return ((← read32BE).toUInt64 <<< 32) ||| (← read32BE).toUInt64
 
+def readFloatBE : Parser Float :=
+  read64BE <&> floatOf8Bytes
+
+def readFloatLE : Parser Float :=
+  read64LE <&> floatOf8Bytes
+
 def readBytes (sz : Nat) : Parser ByteArray := do
   let s ← get
   let pos := s.pos

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -1,7 +1,7 @@
 import Parsec.Utils
-import Parsec.State
+import Parsec.Basic
 
-namespace Parsec
+namespace Parsec.Binary
 
 structure ByteArrayParser.Error where
   pos : Nat
@@ -99,4 +99,5 @@ def readArray (n : Nat) (elem : ByteArrayParser α) : ByteArrayParser (Array α)
 def remaining : ByteArrayParser Nat :=
   return (← read).size - (← get)
 end ByteArrayParser
-end Parsec
+
+end Parsec.Binary

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -54,6 +54,11 @@ def read16LE : ByteArrayParser UInt16 := do
   let b ← read8
   return a.toUInt16 ||| (b.toUInt16 <<< 8)
 
+def read16BE : ByteArrayParser UInt16 := do
+  let a ← read8
+  let b ← read8
+  return (a.toUInt16 <<< 8) ||| b.toUInt16
+
 def read32LE : ByteArrayParser UInt32 := do
   let a ← read8
   let b ← read8
@@ -61,8 +66,18 @@ def read32LE : ByteArrayParser UInt32 := do
   let d ← read8
   return a.toUInt32 ||| (b.toUInt32 <<< 8) ||| (c.toUInt32 <<< 16) ||| (d.toUInt32 <<< 24)
 
+def read32BE : ByteArrayParser UInt32 := do
+  let a ← read8
+  let b ← read8
+  let c ← read8
+  let d ← read8
+  return (a.toUInt32 <<< 24) ||| (b.toUInt32 <<< 16) ||| (c.toUInt32 <<< 8) ||| d.toUInt32
+
 def read64LE : ByteArrayParser UInt64 := do
   return (← read32LE).toUInt64 ||| ((← read32LE).toUInt64 <<< 32)
+
+def read64BE : ByteArrayParser UInt64 := do
+  return ((← read32BE).toUInt64 <<< 32) ||| (← read32BE).toUInt64
 
 def readBytes (sz : Nat) : ByteArrayParser ByteArray := do
   let pos ← get

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -122,11 +122,10 @@ def remaining : Parser Nat := do
   let ba := s.ref
   return ba.size - pos
 
-end Parser
-
 def parse (p : Parser α) (ba : ByteArray) : Except String α := 
   match p { ref := ba, pos := 0 } with
   | ParseResult.success _ res => Except.ok res
   | ParseResult.error s err => Except.error s!"{s.pos}\n{err}"
 
+end Parser
 end Parsec.Binary

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -71,7 +71,7 @@ def readBytes (sz : Nat) : ByteArrayParser ByteArray := do
 
 def readArray (n : Nat) (elem : ByteArrayParser α) : ByteArrayParser (Array α) := do
   let mut arr := #[]
-  for i in [0:n] do
+  for _ in [0:n] do
     arr := arr.push (← elem)
   return arr
 

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -46,6 +46,9 @@ def expectB (b : UInt8) : ByteArrayParser Unit := do
 def expectBs (bs : ByteArray) : ByteArrayParser Unit := do
   for b in bs do expectB b
 
+def expectS (s : String) : ByteArrayParser Unit := do
+  expectBs s.toUTF8
+
 def read16LE : ByteArrayParser UInt16 := do
   let a ← read8
   let b ← read8

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -3,101 +3,118 @@ import Parsec.Basic
 
 namespace Parsec.Binary
 
-structure ByteArrayParser.Error where
+namespace Parser
+
+structure State where
+  ref : ByteArray
   pos : Nat
-  msg : String
-  deriving Repr, Inhabited
 
-instance : ToString ByteArrayParser.Error where
-  toString err := reprStr err
+instance : ParserState State where
+  index s := s.pos
+  next s := { s with pos := s.pos + 1 }
 
-abbrev ByteArrayParser :=
-  ReaderT ByteArray <| StateT Nat <| Except ByteArrayParser.Error
+end Parser
 
-deriving instance Repr for Except
+abbrev Parser := ParsecM String Parser.State
 
-namespace ByteArrayParser
+namespace Parser
 
-def parse (p : ByteArrayParser α) (b : ByteArray) (pos := 0) : Except ByteArrayParser.Error (α × Nat) :=
-  (ReaderT.run p b).run pos
-
-def parse' (p : ByteArrayParser α) (b : ByteArray) (pos := 0) : Except ByteArrayParser.Error α := do
-  return (← p.run b pos).1
+open ParseResult ParserState
 
 @[inline]
-def error (msg : String) : ByteArrayParser α := do
-  Except.error ({ pos := ← get, msg } : Error)
+def getPos : Parser Nat := do
+  let s ← get
+  return s.pos
 
-def peek : ByteArrayParser UInt8 := do
-  let ba ← read
-  let pos ← get
+@[inline]
+def fail (msg : String) : Parser α := fun pos =>
+  error pos msg
+
+@[inline]
+def never : Parser Unit := fun pos => error pos ""
+
+@[inline]
+def peek : Parser UInt8 := do
+  let s ← get
+  let ba := s.ref
+  let pos := s.pos
   if h : pos < ba.size then
     pure <| ba.get ⟨pos, h⟩
   else
-    error "eof"
+    fail "eof"
 
-def read8 : ByteArrayParser UInt8 :=
-  peek <* modify (· + 1)
+def read8 : Parser UInt8 :=
+  peek <* modify fun s => { s with pos := s.pos + 1 }
 
-def expectB (b : UInt8) : ByteArrayParser Unit := do
+def expectB (b : UInt8) : Parser Unit := do
   let b' ← read8
-  unless b = b' do error s!"got {b'}, expected {b}"
+  unless b = b' do fail s!"got {b'}, expected {b}"
 
-def expectBs (bs : ByteArray) : ByteArrayParser Unit := do
+def expectBs (bs : ByteArray) : Parser Unit := do
   for b in bs do expectB b
 
-def expectS (s : String) : ByteArrayParser Unit := do
+def expectS (s : String) : Parser Unit := do
   expectBs s.toUTF8
 
-def read16LE : ByteArrayParser UInt16 := do
+def read16LE : Parser UInt16 := do
   let a ← read8
   let b ← read8
   return a.toUInt16 ||| (b.toUInt16 <<< 8)
 
-def read16BE : ByteArrayParser UInt16 := do
+def read16BE : Parser UInt16 := do
   let a ← read8
   let b ← read8
   return (a.toUInt16 <<< 8) ||| b.toUInt16
 
-def read32LE : ByteArrayParser UInt32 := do
+def read32LE : Parser UInt32 := do
   let a ← read8
   let b ← read8
   let c ← read8
   let d ← read8
   return a.toUInt32 ||| (b.toUInt32 <<< 8) ||| (c.toUInt32 <<< 16) ||| (d.toUInt32 <<< 24)
 
-def read32BE : ByteArrayParser UInt32 := do
+def read32BE : Parser UInt32 := do
   let a ← read8
   let b ← read8
   let c ← read8
   let d ← read8
   return (a.toUInt32 <<< 24) ||| (b.toUInt32 <<< 16) ||| (c.toUInt32 <<< 8) ||| d.toUInt32
 
-def read64LE : ByteArrayParser UInt64 := do
+def read64LE : Parser UInt64 := do
   return (← read32LE).toUInt64 ||| ((← read32LE).toUInt64 <<< 32)
 
-def read64BE : ByteArrayParser UInt64 := do
+def read64BE : Parser UInt64 := do
   return ((← read32BE).toUInt64 <<< 32) ||| (← read32BE).toUInt64
 
-def readBytes (sz : Nat) : ByteArrayParser ByteArray := do
-  let pos ← get
-  let ba ← read
+def readBytes (sz : Nat) : Parser ByteArray := do
+  let s ← get
+  let pos := s.pos
+  let ba := s.ref
   if pos + sz <= ba.size then
-    (pure <| ba.extract pos (pos + sz)) <* modify (· + sz)
+    (pure <| ba.extract pos (pos + sz)) <* modify fun s => { s with pos := s.pos + sz }
   else
-    error s!"eof before {sz} bytes"
+    fail s!"eof before {sz} bytes"
 
-def readString (sz : Nat) : ByteArrayParser String :=
+def readString (sz : Nat) : Parser String :=
   readBytes sz |>.map String.fromUTF8Unchecked
 
-def readArray (n : Nat) (elem : ByteArrayParser α) : ByteArrayParser (Array α) := do
+def readArray (n : Nat) (elem : Parser α) : Parser (Array α) := do
   let mut arr := #[]
   for _ in [0:n] do
     arr := arr.push (← elem)
   return arr
 
-def remaining : ByteArrayParser Nat :=
-  return (← read).size - (← get)
-end ByteArrayParser
+def remaining : Parser Nat := do
+  let s ← get
+  let pos := s.pos
+  let ba := s.ref
+  return ba.size - pos
+
+end Parser
+
+def parse (p : Parser α) (ba : ByteArray) : Except String α := 
+  match p { ref := ba, pos := 0 } with
+  | ParseResult.success _ res => Except.ok res
+  | ParseResult.error s err => Except.error s!"{s.pos}\n{err}"
 
 end Parsec.Binary

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -87,9 +87,15 @@ def read64BE : Parser UInt64 := do
   return ((← read32BE).toUInt64 <<< 32) ||| (← read32BE).toUInt64
 
 def readFloatBE : Parser Float :=
-  read64BE <&> floatOf8Bytes
+  read32BE <&> floatOf4Bytes
 
 def readFloatLE : Parser Float :=
+  read32LE <&> floatOf4Bytes
+
+def readDoubleBE : Parser Float :=
+  read64BE <&> floatOf8Bytes
+
+def readDoubleLE : Parser Float :=
   read64LE <&> floatOf8Bytes
 
 def readBytes (sz : Nat) : Parser ByteArray := do

--- a/src/Parsec/Binary.lean
+++ b/src/Parsec/Binary.lean
@@ -72,6 +72,9 @@ def readBytes (sz : Nat) : ByteArrayParser ByteArray := do
   else
     error s!"eof before {sz} bytes"
 
+def readString (sz : Nat) : ByteArrayParser String :=
+  readBytes sz |>.map String.fromUTF8Unchecked
+
 def readArray (n : Nat) (elem : ByteArrayParser α) : ByteArrayParser (Array α) := do
   let mut arr := #[]
   for _ in [0:n] do

--- a/src/Parsec/State.lean
+++ b/src/Parsec/State.lean
@@ -88,7 +88,7 @@ def orElse {δ} [Backtrackable δ σ] (p : ParsecM ε σ α) (q : Unit → Parse
     | success rem a => success rem a
   | success s a  =>
     match qres with
-    | error rem2 err2 => success s a
+    | error _rem2 _err2 => success s a
     | success rem2 a2 =>
       -- Forward the longest match
       if index s >= index rem2 then

--- a/src/Parsec/String.lean
+++ b/src/Parsec/String.lean
@@ -71,15 +71,15 @@ Convert errors to none
 def option (p : Parsec α) : Parsec $ Option α := fun pos =>
   match p pos with
   | success rem a => success rem (some a)
-  | error rem err => success pos (none)
+  | error _rem _err => success pos (none)
 
 /-
 Try to match but rewind iterator if failure and return success bool
 -/
 def test (p : Parsec α) : Parsec Bool := fun pos =>
   match p pos with
-  | success rem a => success rem true
-  | error rem err => success pos false
+  | success rem _a => success rem true
+  | error _rem _err => success pos false
 
 /-
 Rewind the state on failure

--- a/src/Parsec/Utils.lean
+++ b/src/Parsec/Utils.lean
@@ -15,7 +15,10 @@ instance : Repr ByteArray where
 
 deriving instance Repr for Except
 
-@[extern c inline "*((float*)&#1)"]
+@[extern c inline "((double)(*((float*)&#1)))"]
+opaque floatOf4Bytes : UInt32 → Float
+
+@[extern c inline "*((double*)&#1)"]
 opaque floatOf8Bytes : UInt64 → Float
 
 end Parsec

--- a/src/Parsec/Utils.lean
+++ b/src/Parsec/Utils.lean
@@ -15,4 +15,7 @@ instance : Repr ByteArray where
 
 deriving instance Repr for Except
 
+@[extern c inline "*((float*)&#1)"]
+opaque floatOf8Bytes : UInt64 → Float
+
 end Parsec

--- a/src/Parsec/Utils.lean
+++ b/src/Parsec/Utils.lean
@@ -1,5 +1,6 @@
 namespace String
 
+/-- repeat `s` `n+1` times -/
 def duplicate (s : String) (n : Nat) : String :=
   match n with
   | 0 => s
@@ -8,6 +9,7 @@ def duplicate (s : String) (n : Nat) : String :=
 end String
 
 namespace Parsec
+
 instance : Repr ByteArray where
   reprPrec bs p := reprPrec bs.toList p
 

--- a/src/Parsec/Utils.lean
+++ b/src/Parsec/Utils.lean
@@ -13,4 +13,6 @@ namespace Parsec
 instance : Repr ByteArray where
   reprPrec bs p := reprPrec bs.toList p
 
+deriving instance Repr for Except
+
 end Parsec


### PR DESCRIPTION
This PR consists of following changes:

- [x] make binary parser follow the `ParsecM` model
- [x] severl more binary parser function (endianness, byte to string, etc)
- [x] subtle change to the namespaces (also renaming `Parsec` to `Parser`)

Not yet done:

- [ ] functions to parse float from bytes (waiting for lake's `precompileModules`)
- [ ] doc updates
- [ ] code cleanup and refactoring
- [ ] change to nix package manifest (I have little knowledge about nix)